### PR TITLE
Feature/async_ack

### DIFF
--- a/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncGenericPushConsumerApp.java
+++ b/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncGenericPushConsumerApp.java
@@ -1,0 +1,67 @@
+package io.openmessaging.samples.consumer;
+
+import io.openmessaging.api.Action;
+import io.openmessaging.api.AsyncConsumeContext;
+import io.openmessaging.api.AsyncGenericMessageListener;
+import io.openmessaging.api.Consumer;
+import io.openmessaging.api.GenericMessage;
+import io.openmessaging.api.MessagingAccessPoint;
+import io.openmessaging.api.OMS;
+import io.openmessaging.api.OMSBuiltinKeys;
+import io.openmessaging.samples.MessageSample;
+
+import java.util.Properties;
+
+public class AsyncGenericPushConsumerApp {
+
+    public static void main(String[] args) {
+        //Load and start the vendor implementation from a specific OMS driver URL.
+        final MessagingAccessPoint messagingAccessPoint =
+                OMS.builder()
+                        .region("Shanghai")
+                        .endpoint("127.0.0.1:9876")
+                        .schemaRegistryUrl("http://localhost:1234")
+                        .driver("rocketmq")
+                        .withCredentials(new Properties())
+                        .build();
+
+        Properties properties = new Properties();
+        properties.setProperty(OMSBuiltinKeys.DESERIALIZER, "io.openmessaging.openmeta.impl.Deserializer");
+
+        final Consumer consumer = messagingAccessPoint.createConsumer(properties);
+        consumer.start();
+
+        //Register a shutdown hook to close the opened endpoints.
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                consumer.shutdown();
+            }
+        }));
+
+        //Consume messages from a simple queue.
+        String topic = "NS://HELLO_TOPIC";
+
+        consumer.subscribe(topic, "*", new AsyncGenericMessageListener<MessageSample>() {
+            @Override
+            public Class<MessageSample> payloadClass() {
+                return MessageSample.class;
+            }
+
+            @Override
+            public void consume(GenericMessage<MessageSample> message, final AsyncConsumeContext context) {
+                MessageSample messageSample = message.getValue();
+                System.out.println("Received message: " + messageSample);
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        context.commit(Action.CommitMessage);
+                    }
+                });
+            }
+        });
+
+        consumer.shutdown();
+    }
+
+}

--- a/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncGenericPushConsumerApp.java
+++ b/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncGenericPushConsumerApp.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.samples.consumer;
 
 import io.openmessaging.api.Action;
@@ -52,12 +68,13 @@ public class AsyncGenericPushConsumerApp {
             public void consume(GenericMessage<MessageSample> message, final AsyncConsumeContext context) {
                 MessageSample messageSample = message.getValue();
                 System.out.println("Received message: " + messageSample);
+                // able to commit consumption status in another thread
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
                         context.commit(Action.CommitMessage);
                     }
-                });
+                }).start();
             }
         });
 

--- a/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncPushConsumerApp.java
+++ b/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncPushConsumerApp.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.samples.consumer;
 
 import io.openmessaging.api.Action;
@@ -44,12 +60,13 @@ public class AsyncPushConsumerApp {
         consumer.subscribe(topic, "*", new AsyncMessageListener() {
             @Override
             public void consume(Message message, final AsyncConsumeContext context) {
+                // able to commit consumption status in another thread
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
                         context.commit(Action.CommitMessage);
                     }
-                });
+                }).start();
             }
         });
 

--- a/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncPushConsumerApp.java
+++ b/openmessaging-api-samples/src/main/java/io/openmessaging/samples/consumer/AsyncPushConsumerApp.java
@@ -1,0 +1,59 @@
+package io.openmessaging.samples.consumer;
+
+import io.openmessaging.api.Action;
+import io.openmessaging.api.AsyncConsumeContext;
+import io.openmessaging.api.AsyncMessageListener;
+import io.openmessaging.api.Consumer;
+import io.openmessaging.api.Message;
+import io.openmessaging.api.MessagingAccessPoint;
+import io.openmessaging.api.OMS;
+import io.openmessaging.api.OMSBuiltinKeys;
+
+import java.util.Properties;
+
+public class AsyncPushConsumerApp {
+
+    public static void main(String[] args) {
+        //Load and start the vendor implementation from a specific OMS driver URL.
+        final MessagingAccessPoint messagingAccessPoint =
+                OMS.builder()
+                        .region("Shanghai")
+                        .endpoint("127.0.0.1:9876")
+                        .schemaRegistryUrl("http://localhost:1234")
+                        .driver("rocketmq")
+                        .withCredentials(new Properties())
+                        .build();
+
+        Properties properties = new Properties();
+        properties.setProperty(OMSBuiltinKeys.DESERIALIZER, "io.openmessaging.openmeta.impl.Deserializer");
+
+        final Consumer consumer = messagingAccessPoint.createConsumer(properties);
+        consumer.start();
+
+        //Register a shutdown hook to close the opened endpoints.
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                consumer.shutdown();
+            }
+        }));
+
+        //Consume messages from a simple queue.
+        String topic = "NS://HELLO_TOPIC";
+
+        consumer.subscribe(topic, "*", new AsyncMessageListener() {
+            @Override
+            public void consume(Message message, final AsyncConsumeContext context) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        context.commit(Action.CommitMessage);
+                    }
+                });
+            }
+        });
+
+        consumer.shutdown();
+    }
+
+}

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncConsumeContext.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncConsumeContext.java
@@ -1,0 +1,12 @@
+package io.openmessaging.api;
+
+public abstract class AsyncConsumeContext extends ConsumeContext {
+
+    /**
+     * Asynchronously commit consumption status.
+     * @param action if current message consumed success, should pass {@link Action#CommitMessage} otherwise, should pass {@link
+     * Action#ReconsumeLater}, and this message will be delivered again.
+     */
+    public abstract void commit(Action action);
+
+}

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncConsumeContext.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncConsumeContext.java
@@ -1,11 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.api;
 
 public abstract class AsyncConsumeContext extends ConsumeContext {
 
     /**
      * Asynchronously commit consumption status.
-     * @param action if current message consumed success, should pass {@link Action#CommitMessage} otherwise, should pass {@link
-     * Action#ReconsumeLater}, and this message will be delivered again.
+     *
+     * @param action if current message consumed successfully, should pass {@link Action#CommitMessage} otherwise, should pass
+     * {@link Action#ReconsumeLater}, and this message will be delivered again.
      */
     public abstract void commit(Action action);
 

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncGenericMessageListener.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncGenericMessageListener.java
@@ -1,15 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.api;
 
 /**
- * Async message listener, registered for consume messages by consumer
+ * Async message listener, registered for consume messages by consumer.
+ * <p>
+ * <strong>
+ * Thread safe requirements: this interface will be invoked by multi threads, so users should keep thread safe during
+ * the consume process.
+ * </strong>
+ * </p>
  */
 public interface AsyncGenericMessageListener<T> extends GenericListener<T> {
     /**
      * Asynchronously consumer message interface which allow async commit consumption status, implemented by the application,
      * unstable situations such as network jitter may lead to message duplication, and services sensitive to repeated messages
      * need to guarantee idempotent.
-     * @param message
-     * @param context
+     *
+     * @param message received message
+     * @param context async consume context bound to the message
      */
     void consume(final GenericMessage<T> message, final AsyncConsumeContext context);
 

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncGenericMessageListener.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncGenericMessageListener.java
@@ -1,0 +1,16 @@
+package io.openmessaging.api;
+
+/**
+ * Async message listener, registered for consume messages by consumer
+ */
+public interface AsyncGenericMessageListener<T> extends GenericListener<T> {
+    /**
+     * Asynchronously consumer message interface which allow async commit consumption status, implemented by the application,
+     * unstable situations such as network jitter may lead to message duplication, and services sensitive to repeated messages
+     * need to guarantee idempotent.
+     * @param message
+     * @param context
+     */
+    void consume(final GenericMessage<T> message, final AsyncConsumeContext context);
+
+}

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncMessageListener.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncMessageListener.java
@@ -1,7 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.api;
 
 /**
- * Async message listener, registered for consume messages by consumer
+ * Async message listener, registered for consume messages by consumer.
+ *
+ * <p>
+ * <strong>
+ * Thread safe requirements: this interface will be invoked by multi threads, so users should keep thread safe during
+ * the consume process.
+ * </strong>
+ * </p>
  */
 public interface AsyncMessageListener {
 
@@ -9,8 +32,9 @@ public interface AsyncMessageListener {
      * Asynchronously consumer message interface which allow async commit consumption status, implemented by the application,
      * unstable situations such as network jitter may lead to message duplication, and services sensitive to repeated messages
      * need to guarantee idempotent.
-     * @param message
-     * @param context
+     *
+     * @param message received message
+     * @param context async consume context bound to the message
      */
     void consume(final Message message, final AsyncConsumeContext context);
 

--- a/openmessaging-api/src/main/java/io/openmessaging/api/AsyncMessageListener.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/AsyncMessageListener.java
@@ -1,0 +1,17 @@
+package io.openmessaging.api;
+
+/**
+ * Async message listener, registered for consume messages by consumer
+ */
+public interface AsyncMessageListener {
+
+    /**
+     * Asynchronously consumer message interface which allow async commit consumption status, implemented by the application,
+     * unstable situations such as network jitter may lead to message duplication, and services sensitive to repeated messages
+     * need to guarantee idempotent.
+     * @param message
+     * @param context
+     */
+    void consume(final Message message, final AsyncConsumeContext context);
+
+}

--- a/openmessaging-api/src/main/java/io/openmessaging/api/Consumer.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/Consumer.java
@@ -74,35 +74,51 @@ public interface Consumer extends ConsumerBase, Admin {
 
     /**
      * Subscribe to messages with async message listener.
-     * @param topic
-     * @param subExpression
-     * @param listener
+     *
+     * @param topic message topic.
+     * @param subExpression Subscribe to the filter expression string, which the broker filters based on this
+     * expression. <br> eg: "tag1 || tag2 || tag3"<br>, if subExpression is equal to null or *, it means subscribe all
+     * messages.
+     * @param listener Message callback listener which enable async commit consumption status, the consumer receives the
+     * message and then passes it to the message callback listener for consumption.
      */
     void subscribe(final String topic, final String subExpression, final AsyncMessageListener listener);
 
     /**
      * Subscribe to messages with async message listener, which can be filtered using SQL expressions.
-     * @param topic
-     * @param selector
-     * @param listener
+     *
+     * @param topic message topic
+     * @param selector Subscribe to the message selector (can be empty, indicating no filtering), the ONS server filters
+     * according to the expression in this selector. Currently supports two expression syntax: {@link
+     * ExpressionType#TAG}, {@link ExpressionType#SQL92} Among them, the effect of TAG filtering is consistent with the
+     * above interface.
+     * @param listener Message callback listener which enable async commit consumption status, the consumer receives the
+     * message and then passes it to the message callback listener for consumption.
      */
     void subscribe(final String topic, final MessageSelector selector, final AsyncMessageListener listener);
 
     /**
      * Subscribe to messages with async message listener.
-     * @param topic
-     * @param subExpression
-     * @param listener
-     * @param <T>
+     *
+     * @param topic message topic.
+     * @param subExpression Subscribe to the filter expression string, which the broker filters based on this
+     * expression. <br> eg: "tag1 || tag2 || tag3"<br>, if subExpression is equal to null or *, it means subscribe all
+     * messages.
+     * @param listener Message callback listener which enable async commit consumption status, the consumer receives the
+     * message and then passes it to the message callback listener for consumption.
      */
     <T> void subscribe(final String topic, final String subExpression, final AsyncGenericMessageListener<T> listener);
 
     /**
      * Subscribe to messages with async message listener, which can be filtered using SQL expressions.
-     * @param topic
-     * @param selector
-     * @param listener
-     * @param <T>
+     *
+     * @param topic message topic
+     * @param selector Subscribe to the message selector (can be empty, indicating no filtering), the ONS server filters
+     * according to the expression in this selector. Currently supports two expression syntax: {@link
+     * ExpressionType#TAG}, {@link ExpressionType#SQL92} Among them, the effect of TAG filtering is consistent with the
+     * above interface.
+     * @param listener Message callback listener which enable async commit consumption status, the consumer receives the
+     * message and then passes it to the message callback listener for consumption.
      */
     <T> void subscribe(final String topic, final MessageSelector selector, final AsyncGenericMessageListener<T> listener);
 }

--- a/openmessaging-api/src/main/java/io/openmessaging/api/Consumer.java
+++ b/openmessaging-api/src/main/java/io/openmessaging/api/Consumer.java
@@ -71,4 +71,38 @@ public interface Consumer extends ConsumerBase, Admin {
      * @param listener Message callback listener
      */
     <T> void subscribe(final String topic, final MessageSelector selector, final GenericMessageListener<T> listener);
+
+    /**
+     * Subscribe to messages with async message listener.
+     * @param topic
+     * @param subExpression
+     * @param listener
+     */
+    void subscribe(final String topic, final String subExpression, final AsyncMessageListener listener);
+
+    /**
+     * Subscribe to messages with async message listener, which can be filtered using SQL expressions.
+     * @param topic
+     * @param selector
+     * @param listener
+     */
+    void subscribe(final String topic, final MessageSelector selector, final AsyncMessageListener listener);
+
+    /**
+     * Subscribe to messages with async message listener.
+     * @param topic
+     * @param subExpression
+     * @param listener
+     * @param <T>
+     */
+    <T> void subscribe(final String topic, final String subExpression, final AsyncGenericMessageListener<T> listener);
+
+    /**
+     * Subscribe to messages with async message listener, which can be filtered using SQL expressions.
+     * @param topic
+     * @param selector
+     * @param listener
+     * @param <T>
+     */
+    <T> void subscribe(final String topic, final MessageSelector selector, final AsyncGenericMessageListener<T> listener);
 }


### PR DESCRIPTION
- enable consumer subscribe with AsyncMessageLisener to commit consumption status asynchronously, e.g. in another thread
- user case in io/openmessaging/samples/consumer